### PR TITLE
Updated git repo requirement, fixed typo.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ Jinja2==2.8
 MarkupSafe==0.23
 oauth==1.0.1
 Werkzeug==0.11.11
--e git+git@github.com:ucfcdl/pylti.git@roles#egg=PyLTI
+-e git+https://github.com/ucfcdl/pylti.git@roles#egg=PyLTI

--- a/templates/launch.htm.j2
+++ b/templates/launch.htm.j2
@@ -11,7 +11,7 @@
         <li>Template: templates/launch.htm.j2</li>
     </ul>
 
-    <p>Note: You can see all the LIT params in your server console.</p>
+    <p>Note: You can see all the LTI params in your server console.</p>
 
     <p>Here's an example of displaying an image with Flask:</p>
     <img src={{ url_for('static', filename='img/example.jpg') }} alt="Example image" />


### PR DESCRIPTION
Changed requirements.txt to refer to https for the call to git repo, fixed typo on launch.htm.j2

Requirements.txt old pointer to git repo would error if the user didn't have SSH access to the repo. This version should work as long as it is publicly visible.