### PR TITLE
escaping user provided variables in Jinja templates

### DIFF
--- a/templates/launch.htm.j2
+++ b/templates/launch.htm.j2
@@ -6,7 +6,7 @@
     <p>{{msg}}</p>
 
     <ul>
-        <li>lis_person_name_full is <b>{{ lis_person_name_full }}</b></li>
+        <li>lis_person_name_full is <b>{{ lis_person_name_full|e}}</b></li>
         <li>View/Route: views.py '/launch'</li>
         <li>Template: templates/launch.htm.j2</li>
     </ul>


### PR DESCRIPTION
Hi there,

We have a free program analysis tool for Python based web projects, called Bento. While we were scanning GitHub projects for issues, your project triggered a warning for unescaped Jinja templates.

You are passing the host parameter to your jinja template in views.py:63. `lis_person_name_full` comes from `request.form.get('lis_person_name_full')`. This line may be susceptible to XSS attacks. I went ahead and html-escaped the `lis_person_name_full` variable in launch.htm.j2 file using the `{{value|e}}` pattern in Jinja. (https://jinja.palletsprojects.com/en/2.10.x/templates/#working-with-manual-escaping).

Note that if your template file extensions ended with `.html`, `.htm`, `.xml`, or `.xhtml`, they would have been automatically html escaped. For more, take a look here: https://checks.bento.dev/en/latest/flake8-flask/unescaped-file-extension/

Bento flagged a few other issues including the usage of "bare except" but I didn't mess with those to keep this PR simple. If you are curious, feel free download and give Bento a try (https://bento.dev)